### PR TITLE
feat: add optional scopes parameter to FaydaOptions

### DIFF
--- a/.changeset/true-bats-read.md
+++ b/.changeset/true-bats-read.md
@@ -1,0 +1,12 @@
+---
+"fayda": patch
+---
+
+Add optional `scopes` parameter to `FaydaOptions` interface for customizable OAuth scopes.
+
+- **New Feature**: Added `scopes?: string[]` parameter to allow custom OAuth scope configuration
+- **Default Behavior**: Maintains existing default scopes `["openid", "profile", "email"]` when not provided
+- **Backward Compatible**: Existing implementations continue to work without changes
+- **Usage**: Pass custom scopes like `scopes: ["openid", "profile", "email", "address"]` for additional permissions
+
+This enables flexible authentication by allowing users to request specific OAuth scopes based on their application needs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import type { User } from "better-auth";
 import { genericOAuth } from "better-auth/plugins";
 import { decodeJwt, importJWK, SignJWT } from "jose";
 
-const DISCOVERY_URL = "https://esignet.ida.fayda.et/.well-known/openid-configuration";
+const DISCOVERY_URL =
+  "https://esignet.ida.fayda.et/.well-known/openid-configuration";
 const USER_INFO_URL = "https://esignet.ida.fayda.et/v1/esignet/oidc/userinfo";
 const TOKEN_ENDPOINT = "https://esignet.ida.fayda.et/v1/esignet/oauth/v2/token";
 
@@ -19,7 +20,12 @@ export interface FaydaOptions {
 
 type Fayda = Promise<ReturnType<typeof genericOAuth>>;
 
-export const fayda = async ({ clientId, privateKey, redirectUrl, scopes }: FaydaOptions): Fayda => {
+export const fayda = async ({
+  clientId,
+  privateKey,
+  redirectUrl,
+  scopes,
+}: FaydaOptions): Fayda => {
   return genericOAuth({
     config: [
       {
@@ -32,7 +38,8 @@ export const fayda = async ({ clientId, privateKey, redirectUrl, scopes }: Fayda
 
         tokenUrlParams: {
           client_assertion: await generateSignedJwt(clientId, privateKey),
-          client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         },
 
         scopes: scopes?.length ? scopes : DEFAULT_SCOPES,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,23 @@ import type { User } from "better-auth";
 import { genericOAuth } from "better-auth/plugins";
 import { decodeJwt, importJWK, SignJWT } from "jose";
 
-const DISCOVERY_URL =
-  "https://esignet.ida.fayda.et/.well-known/openid-configuration";
+const DISCOVERY_URL = "https://esignet.ida.fayda.et/.well-known/openid-configuration";
 const USER_INFO_URL = "https://esignet.ida.fayda.et/v1/esignet/oidc/userinfo";
 const TOKEN_ENDPOINT = "https://esignet.ida.fayda.et/v1/esignet/oauth/v2/token";
+
+// Default scopes for Fayda authentication
+const DEFAULT_SCOPES = ["openid", "profile", "email"];
 
 export interface FaydaOptions {
   clientId: string;
   privateKey: string;
   redirectUrl?: string;
+  scopes?: string[];
 }
 
 type Fayda = Promise<ReturnType<typeof genericOAuth>>;
 
-export const fayda = async ({
-  clientId,
-  privateKey,
-  redirectUrl,
-}: FaydaOptions): Fayda => {
+export const fayda = async ({ clientId, privateKey, redirectUrl, scopes }: FaydaOptions): Fayda => {
   return genericOAuth({
     config: [
       {
@@ -33,11 +32,10 @@ export const fayda = async ({
 
         tokenUrlParams: {
           client_assertion: await generateSignedJwt(clientId, privateKey),
-          client_assertion_type:
-            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         },
 
-        scopes: ["openid", "profile", "email"],
+        scopes: scopes?.length ? scopes : DEFAULT_SCOPES,
 
         async getUserInfo(tokens) {
           const userInfo = await betterFetch<Blob>(USER_INFO_URL, {


### PR DESCRIPTION
- Add optional scopes parameter accepting string arrays
- Defaults to ['openid', 'profile', 'email'] when not provided
- Supports custom OAuth scopes for flexible authentication
- Maintains backward compatibility with existing implementations

Breaking changes: None
Closes: N/A